### PR TITLE
Add CLI and clipboard to generate_tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,36 +2,38 @@
 
 Welcome to the **HelperScripts** repository! This repository contains small scripts that help with everyday tasks or can be useful for various workflows. Currently, it includes two scripts, both licensed under the [GNU General Public License v3.0 (GPL-3.0)](https://www.gnu.org/licenses/gpl-3.0.en.html):
 
-1. [**generate_filtered_tree.py**](#generate_filtered_treepy)
-2. [**code_summarizer.py**](#code_summarizerpy)
+1. [**generate_tree.py**](#generate_treepy)
+2. [**project-sum.py**](#project-sumpy)
 
 ---
 
-## generate_filtered_tree.py
+## generate_tree.py
 
-This script generates a directory tree for a specified path, excluding certain directories and files. The result is saved in a text file (*project_tree.txt*).
+This script generates a directory tree for a specified path, excluding certain directories and files. The result is copied to the clipboard if possible, otherwise it is written to a text file in the script folder.
 
 ### How It Works
 
 - Recursively scans the specified root folder and all of its subfolders.
 - Certain directories (e.g., `bin`, `obj`, `.git`, etc.) are excluded by default.
 - Certain files or file extensions (e.g., `*.dll`, `*.pdb`, `*.exe`) are also excluded by default.
-- The generated directory tree is saved in a file named `project_tree.txt` located in the provided project path.
+- The generated directory tree is copied to the clipboard if possible. If clipboard access is not available, it is written to a text file in the script folder.
 
 ### Usage
 
-1. **Run the script**:  
+1. **Run the script**:
    ```bash
-   python generate_filtered_tree.py
+   python generate_tree.py <path>
    ```
-2. **Enter the project path**: Once started, you will be prompted to input the path where the directory tree should be generated.
-3. **Result**: The output is saved as `project_tree.txt` in the same directory you provided.
+   - **<path>**: The folder for which the tree should be generated.
+2. **Result**:
+   - If `pyperclip` is installed, the directory tree is copied to your clipboard.
+   - Otherwise, a text file named after the last directory in `<path>` is created in the script's folder.
 
 Feel free to customize the lists of directories and files to exclude according to your needs.
 
 ---
 
-## code_summarizer.py
+## project-sum.py
 
 This script recursively collects files of specified extensions (e.g., `.cs`, `.py`) within a project directory, cleans them based on file-type-specific rules, and aggregates their content into a single output. If possible, it also copies the final text to the clipboard.
 
@@ -44,16 +46,16 @@ This script recursively collects files of specified extensions (e.g., `.cs`, `.p
 
 ### Usage
 
-1. **Run the script**:  
+1. **Run the script**:
    ```bash
-   python code_summarizer.py <path> <extension1> [<extension2> ...]
+   python project-sum.py <path> <extension1> [<extension2> ...]
    ```
    - **<path>**: The base folder to search through (e.g., the root directory of a .NET solution).
    - **<extension1> [<extension2> ...]**: The file types you want to process (e.g., `.cs`, `.py`).
    
 2. **Example**:  
    ```bash
-   python code_summarizer.py "C:/Projects/MySolution" .cs .py
+   python project-sum.py "C:/Projects/MySolution" .cs .py
    ```
    
 3. **Output**:  

--- a/generate_tree.py
+++ b/generate_tree.py
@@ -1,4 +1,12 @@
 import os
+import argparse
+
+# Try to import pyperclip to enable clipboard copy
+try:
+    import pyperclip
+    clipboard_available = True
+except ImportError:
+    clipboard_available = False
 
 def generate_filtered_tree(path, exclude_dirs=None, exclude_files=None):
     """
@@ -52,15 +60,30 @@ def generate_filtered_tree(path, exclude_dirs=None, exclude_files=None):
 
 # Example usage
 if __name__ == "__main__":
-    project_path = input("Enter the path to your project: ").strip()
+    parser = argparse.ArgumentParser(description="Generate a filtered directory tree.")
+    parser.add_argument("path", type=str, help="Path to the project directory.")
+    args = parser.parse_args()
+
+    project_path = args.path
     if not os.path.isdir(project_path):
         print("Invalid directory path.")
-    else:
-        tree = generate_filtered_tree(project_path)
+        raise SystemExit(1)
 
-        # Save to file
-        output_file = os.path.join(project_path, "project_tree.txt")
+    tree = generate_filtered_tree(project_path)
+
+    copied = False
+    if clipboard_available:
+        try:
+            pyperclip.copy(tree)
+            print("Directory tree copied to clipboard.")
+            copied = True
+        except Exception as e:
+            print(f"Failed to copy to clipboard: {e}")
+
+    if not copied:
+        base_name = os.path.basename(os.path.abspath(os.path.normpath(project_path))) + ".txt"
+        output_dir = os.path.dirname(__file__)
+        output_file = os.path.join(output_dir, base_name)
         with open(output_file, "w", encoding="utf-8") as f:
             f.write(tree)
-
         print(f"Directory tree saved to: {output_file}")


### PR DESCRIPTION
## Summary
- enhance `generate_tree.py` with command line interface
- copy output to clipboard if `pyperclip` is available
- save to a named text file in script directory when clipboard copy isn't possible
- update documentation for new behaviour and current script names

## Testing
- `python -m py_compile generate_tree.py project-sum.py`
- `python generate_tree.py .`

------
https://chatgpt.com/codex/tasks/task_e_6840c3d2c0d4832e9aa4cb8bca5ab190